### PR TITLE
Copy load screens from broadcaster to receivers during setup / installation process

### DIFF
--- a/bin/msend_video
+++ b/bin/msend_video
@@ -42,8 +42,9 @@ first_byte_send_time = None
 last_byte_send_time = None
 end_loading_screen_signal_time = None
 play_signal_time = None
+chunk_size = 4096
 while True:
-    data = sys.stdin.buffer.read(4096)
+    data = sys.stdin.buffer.read(chunk_size)
     if not data and end_loading_screen_signal_time and play_signal_time:
         # Need to make sure we've sent all these signals before breaking
         # Once data returns falsey, it should continue to be falsey forever.
@@ -66,6 +67,8 @@ while True:
 
     if data:
         bytes_sent += multicast_helper.send(data, MulticastHelper.VIDEO_PORT)
+        # Rate limit to sending 5 MB/s
+        time.sleep(1 / (5 * 1024 * 1024 / chunk_size))
     else:
         # We've sent all our data and we're just waiting for the signals to be sent. Avoid exhausting CPU.
         if not last_byte_send_time:

--- a/bin/msend_video
+++ b/bin/msend_video
@@ -67,7 +67,27 @@ while True:
 
     if data:
         bytes_sent += multicast_helper.send(data, MulticastHelper.VIDEO_PORT)
-        # Rate limit to sending 5 MB/s
+
+        # This sleep rate limits sending to 5 MB/s. This is especially important when playing back
+        # local files. Without the rate limit, files may send as fast as network bandwidth permits, which would
+        # prevent control messages from being received in a timely manner. Without rate limiting, when playing
+        # local files, we observed that a control message could be sent over the network and received ~10
+        # seconds later -- a delay because the tubes were clogged.
+        #
+        # Another reason rate limiting is important is because the transmitted video can get corrupted if it is
+        # sent too fast. Specifically, there may be missing chunks of the video -- the receiver won't receive all
+        # of the bytes that the broadcaster sent. This corruption might occur on ~50% of the sends. Example
+        # output without the rate limit:
+        # https://gist.githubusercontent.com/dasl-/d06329d31df346b936419e394d364bc7/raw/7097647283435e888e8d5e1896e4472c7578273c/gistfile1.txt
+        #
+        # With the rate limit, all of the bytes are received. Example output with the rate limit:
+        # https://gist.githubusercontent.com/dasl-/cf10aa4da8d47a96c219e38d2bcfd6d8/raw/3aa9378172a97a1a45a72fc234b647f93f735b03/gistfile1.txt
+        #
+        # We used to rate limit via a `pv --rate-limit 4M` in our pipeline. But we found that this was for some
+        # not able to prevent the corruption described above. I'm not sure why -- perhaps `pv` buffers input
+        # internally and can emit output in bursty chunks, which might allow transient periods where we transmit
+        # greater too quickly?? In any case, replacing the `pv` clause with this sleep seems better able to
+        # prevent the aforementioned corruption.
         time.sleep(1 / (5 * 1024 * 1024 / chunk_size))
     else:
         # We've sent all our data and we're just waiting for the signals to be sent. Avoid exhausting CPU.

--- a/bin/msend_video
+++ b/bin/msend_video
@@ -41,8 +41,13 @@ bytes_sent = 0
 first_byte_send_time = None
 end_loading_screen_signal_time = None
 play_signal_time = None
+import hashlib
+chunk = 0
 while True:
+    chunk += 1
     data = sys.stdin.buffer.read(4096)
+    hash_s = hashlib.md5(data).hexdigest()
+    logger.info(f"Sent {chunk}: {hash_s}")
     if not data and end_loading_screen_signal_time and play_signal_time:
         # Need to make sure we've sent all these signals before breaking
         # Once data returns falsey, it should continue to be falsey forever.

--- a/bin/msend_video
+++ b/bin/msend_video
@@ -39,6 +39,7 @@ multicast_helper = MulticastHelper().setup_broadcaster_socket()
 control_message_helper = ControlMessageHelper().setup_for_broadcaster()
 bytes_sent = 0
 first_byte_send_time = None
+last_byte_send_time = None
 end_loading_screen_signal_time = None
 play_signal_time = None
 while True:
@@ -67,9 +68,16 @@ while True:
         bytes_sent += multicast_helper.send(data, MulticastHelper.VIDEO_PORT)
     else:
         # We've sent all our data and we're just waiting for the signals to be sent. Avoid exhausting CPU.
+        if not last_byte_send_time:
+            last_byte_send_time = time.time()
         time.sleep(0.01)
 
 if args.end_of_video_magic_bytes:
     bytes_sent += multicast_helper.send(args.end_of_video_magic_bytes.encode(), MulticastHelper.VIDEO_PORT)
 
-logger.info(f"Finished sending video. Sent {bytes_sent} bytes.")
+if not last_byte_send_time:
+    last_byte_send_time = time.time()
+
+logger.info(f"Finished sending video. Sent {bytes_sent} bytes in " +
+    f"{round(last_byte_send_time - first_byte_send_time, 2)} s " +
+    f"({round((bytes_sent / 1024) / (last_byte_send_time - first_byte_send_time), 2)} KB/s).")

--- a/bin/msend_video
+++ b/bin/msend_video
@@ -86,7 +86,10 @@ while True:
         # We used to rate limit via a `pv --rate-limit 4M` in our pipeline. But we found that this was for some
         # not able to prevent the corruption described above. I'm not sure why -- perhaps `pv` buffers input
         # internally and can emit output in bursty chunks, which might allow transient periods where we transmit
-        # greater too quickly?? In any case, replacing the `pv` clause with this sleep seems better able to
+        # greater too quickly?? Some testing with `pv --no-splice --buffer-size 512 --rate-limit 4M` seemed to
+        # work better and might have solved the problem, but that is quite fiddly.
+        #
+        # In any case, replacing the `pv` clause with this sleep seems better able to
         # prevent the aforementioned corruption.
         time.sleep(1 / (5 * 1024 * 1024 / chunk_size))
     else:

--- a/bin/msend_video
+++ b/bin/msend_video
@@ -41,13 +41,8 @@ bytes_sent = 0
 first_byte_send_time = None
 end_loading_screen_signal_time = None
 play_signal_time = None
-import hashlib
-chunk = 0
 while True:
-    chunk += 1
     data = sys.stdin.buffer.read(4096)
-    hash_s = hashlib.md5(data).hexdigest()
-    logger.info(f"Sent {chunk}: {hash_s}")
     if not data and end_loading_screen_signal_time and play_signal_time:
         # Need to make sure we've sent all these signals before breaking
         # Once data returns falsey, it should continue to be falsey forever.

--- a/install/setup_broadcaster_and_receivers
+++ b/install/setup_broadcaster_and_receivers
@@ -37,6 +37,7 @@ def main():
         install_dependencies(cmd_runner, args.omxplayer_branch)
     if args.install_app:
         install_app(cmd_runner, args.dont_disable_wifi)
+    copy_loading_screens_from_broadcaster_to_receivers()
 
     # The step install_app require a restart
     restart_hosts_if_necessary(cmd_runner, is_last_step = True)
@@ -181,6 +182,10 @@ def install_bootstrap_dependencies():
 
     print("Installing bootstrap python dependencies...")
     run_cmd_with_realtime_output(ROOT_DIR + '/install/install_dependencies.sh -p -t broadcaster')
+
+def copy_loading_screens_from_broadcaster_to_receivers():
+    from piwall2.broadcaster.loadingscreenhelper import LoadingScreenHelper
+    LoadingScreenHelper().copy_loading_screens_from_broadcaster_to_receivers()
 
 def is_program_installed(program):
     try:

--- a/install/setup_broadcaster_and_receivers
+++ b/install/setup_broadcaster_and_receivers
@@ -184,6 +184,7 @@ def install_bootstrap_dependencies():
     run_cmd_with_realtime_output(ROOT_DIR + '/install/install_dependencies.sh -p -t broadcaster')
 
 def copy_loading_screens_from_broadcaster_to_receivers():
+    print("Copying loading screens from broadcaster to receivers if necessary...")
     from piwall2.broadcaster.loadingscreenhelper import LoadingScreenHelper
     LoadingScreenHelper().copy_loading_screens_from_broadcaster_to_receivers()
 

--- a/piwall2/broadcaster/loadingscreenhelper.py
+++ b/piwall2/broadcaster/loadingscreenhelper.py
@@ -113,10 +113,11 @@ class LoadingScreenHelper:
         ).decode('utf-8').strip()
 
         cmd = f"md5sum --check --strict <( echo '{checksum}' )"
+        print("dasldasl cmd: " + cmd)
         return_code, stdout, stderr = cmd_runner.run_dsh(
             cmd, include_broadcaster = False, raise_on_failure = False, return_output = True
         )
-        print("dasldasl: " + stdout)
+        print("dasldasl dshoutput: " + stdout.decode('utf-8'))
         raise Exception("foobarr")
 
     def __load_config_if_not_loaded(self):

--- a/piwall2/broadcaster/loadingscreenhelper.py
+++ b/piwall2/broadcaster/loadingscreenhelper.py
@@ -71,7 +71,7 @@ class LoadingScreenHelper:
         self.__control_message_helper.send_msg(ControlMessageHelper.TYPE_SHOW_LOADING_SCREEN, msg)
 
     # This method is called by setup scripts. It iterates through all loading screens in the config file.
-    # For loading screen:
+    # For each loading screen:
     #   1) check if it exists on the broadcaster. If not, throw an exception.
     #   2) check if it exists on each receiver. If not, copy it to all receivers.
     def copy_loading_screens_from_broadcaster_to_receivers(self):

--- a/piwall2/broadcaster/loadingscreenhelper.py
+++ b/piwall2/broadcaster/loadingscreenhelper.py
@@ -143,7 +143,7 @@ class LoadingScreenHelper:
         for video_path, match_count in video_to_match_count_map.items():
             if match_count < num_receivers:
                 self.__logger.info("Loading screen needs to be copied to one or more receivers " +
-                    f"(only matched on {match_count} of {num_receivers} receivers): {video_path}")
+                    f"(matched on {match_count} of {num_receivers} receivers): {video_path}")
                 loading_screens_that_need_to_be_copied.append(video_path)
             else:
                 self.__logger.info(f"Loading screen doesn't need to be copied receivers {video_path}")

--- a/piwall2/broadcaster/loadingscreenhelper.py
+++ b/piwall2/broadcaster/loadingscreenhelper.py
@@ -110,13 +110,13 @@ class LoadingScreenHelper:
             shell = True,
             executable = '/usr/bin/bash',
             stderr = subprocess.STDOUT
-        )
+        ).decode('utf-8').strip()
 
         cmd = f"md5sum --check --strict <( echo '{checksum}' )"
         return_code, stdout, stderr = cmd_runner.run_dsh(
             cmd, include_broadcaster = False, raise_on_failure = False, return_output = True
         )
-        print(stdout)
+        print("dasldasl: " + stdout)
         raise Exception("foobarr")
 
     def __load_config_if_not_loaded(self):

--- a/piwall2/broadcaster/loadingscreenhelper.py
+++ b/piwall2/broadcaster/loadingscreenhelper.py
@@ -146,7 +146,7 @@ class LoadingScreenHelper:
                     f"(matched on {match_count} of {num_receivers} receivers): {video_path}")
                 loading_screens_that_need_to_be_copied.append(video_path)
             else:
-                self.__logger.info(f"Loading screen doesn't need to be copied receivers {video_path}")
+                self.__logger.info(f"Loading screen doesn't need to be copied to receivers {video_path}")
         return loading_screens_that_need_to_be_copied
 
     def __load_config_if_not_loaded(self):

--- a/piwall2/broadcaster/videobroadcaster.py
+++ b/piwall2/broadcaster/videobroadcaster.py
@@ -252,6 +252,15 @@ class VideoBroadcaster:
         # control messages from being received in a timely manner. Without `pv` here, when playing local files,
         # we observed that a control message could be sent over the network and received ~10 seconds later --
         # a delay because the tubes were clogged.
+        #
+        # Another reason `pv` is important is because the transmitted video can get corrupted if it is sent
+        # too fast. Specifically, there may be missing chunks of the video -- the receiver won't receive all
+        # of the bytes that the broadcaster sent. This corruption might occur on ~50% of the sends. Example
+        # output without the rate limit:
+        # https://gist.githubusercontent.com/dasl-/d06329d31df346b936419e394d364bc7/raw/7097647283435e888e8d5e1896e4472c7578273c/gistfile1.txt
+        #
+        # With the rate limit, all of the bytes are received. Example output with the rate limit:
+        # https://gist.githubusercontent.com/dasl-/cf10aa4da8d47a96c219e38d2bcfd6d8/raw/152895f07f16717cf678f981ad40c4bc9ffebe91/gistfile1.txt
         video_broadcast_cmd = ("set -o pipefail && export SHELLOPTS && " +
             f"pv --rate-limit 4M | tee >({burst_throttling_clause}) >({broadcasting_clause}) >/dev/null")
         self.__logger.info(f"Running broadcast command: {video_broadcast_cmd}")

--- a/piwall2/broadcaster/videobroadcaster.py
+++ b/piwall2/broadcaster/videobroadcaster.py
@@ -246,23 +246,8 @@ class VideoBroadcaster:
 
         # Mix the best audio with the video and send via multicast
         # See: https://github.com/dasl-/piwall2/blob/main/docs/best_video_container_format_for_streaming.adoc
-        #
-        # Use `pv` to rate limit how fast we send the video. This is especially important when playing back
-        # local files. Without `pv`, they may send as fast as network bandwidth permits, which would prevent
-        # control messages from being received in a timely manner. Without `pv` here, when playing local files,
-        # we observed that a control message could be sent over the network and received ~10 seconds later --
-        # a delay because the tubes were clogged.
-        #
-        # Another reason `pv` is important is because the transmitted video can get corrupted if it is sent
-        # too fast. Specifically, there may be missing chunks of the video -- the receiver won't receive all
-        # of the bytes that the broadcaster sent. This corruption might occur on ~50% of the sends. Example
-        # output without the rate limit:
-        # https://gist.githubusercontent.com/dasl-/d06329d31df346b936419e394d364bc7/raw/7097647283435e888e8d5e1896e4472c7578273c/gistfile1.txt
-        #
-        # With the rate limit, all of the bytes are received. Example output with the rate limit:
-        # https://gist.githubusercontent.com/dasl-/cf10aa4da8d47a96c219e38d2bcfd6d8/raw/152895f07f16717cf678f981ad40c4bc9ffebe91/gistfile1.txt
         video_broadcast_cmd = ("set -o pipefail && export SHELLOPTS && " +
-            f"pv --rate-limit 4M | tee >({burst_throttling_clause}) >({broadcasting_clause}) >/dev/null")
+            f"tee >({burst_throttling_clause}) >({broadcasting_clause}) >/dev/null")
         self.__logger.info(f"Running broadcast command: {video_broadcast_cmd}")
 
         # Info on start_new_session: https://gist.github.com/dasl-/1379cc91fb8739efa5b9414f35101f5f

--- a/piwall2/receiver/videoreceiver.py
+++ b/piwall2/receiver/videoreceiver.py
@@ -28,14 +28,8 @@ class VideoReceiver:
         measurement_window_bytes_count = 0
         total_bytes_count = 0
 
-        import hashlib
-        chunk = 0
         while True:
-            chunk += 1
             video_bytes = multicast_helper.receive(MulticastHelper.VIDEO_PORT)
-            hash_s = hashlib.md5(video_bytes).hexdigest()
-            self.__logger.info(f"Received {chunk}: {hash_s}")
-
             if total_bytes_count == 0:
                 # Subsequent bytes after the first packet should be received more quickly
                 socket.settimeout(30)

--- a/piwall2/receiver/videoreceiver.py
+++ b/piwall2/receiver/videoreceiver.py
@@ -28,8 +28,14 @@ class VideoReceiver:
         measurement_window_bytes_count = 0
         total_bytes_count = 0
 
+        import hashlib
+        chunk = 0
         while True:
+            chunk += 1
             video_bytes = multicast_helper.receive(MulticastHelper.VIDEO_PORT)
+            hash_s = hashlib.md5(video_bytes).hexdigest()
+            self.__logger.info(f"Received {chunk}: {hash_s}")
+
             if total_bytes_count == 0:
                 # Subsequent bytes after the first packet should be received more quickly
                 socket.settimeout(30)

--- a/utils/msend_file_to_receivers
+++ b/utils/msend_file_to_receivers
@@ -49,13 +49,14 @@ cmd = (f'{root_dir}/bin/msend_video --end-of-video-magic-bytes {VideoBroadcaster
     f'< {shlex.quote(args.input_file)}')
 cmd_runner.run_cmd_with_realtime_output(cmd)
 
+while receive_file_proc.poll() is None:
+    time.sleep(0.1)
+
 logger.info("Restarting receiver service on receivers...")
 cmd_runner = CmdRunner()
 cmd = 'sudo systemctl restart piwall2_receiver.service'
 cmd_runner.run_dsh(cmd, include_broadcaster = False)
 
-while receive_file_proc.poll() is None:
-    time.sleep(0.1)
 if receive_file_proc.returncode != 0:
     raise Exception(f"The receive_file process exited non-zero: {receive_file_proc.returncode}.")
 

--- a/utils/msend_file_to_receivers
+++ b/utils/msend_file_to_receivers
@@ -45,8 +45,8 @@ receive_file_proc = cmd_runner.run_dsh(cmd, include_broadcaster = False, wait_fo
 time.sleep(2)
 
 logger.info("Sending file to receivers...")
-cmd = (f'{root_dir}/bin/msend_video --end-of-video-magic-bytes {VideoBroadcaster.END_OF_VIDEO_MAGIC_BYTES.decode()} ' +
-    f'< {shlex.quote(args.input_file)}')
+cmd = (f'set -o pipefail && export SHELLOPTS && cat {shlex.quote(args.input_file)} | pv --rate-limit 4M | ' +
+    f'{root_dir}/bin/msend_video --end-of-video-magic-bytes {VideoBroadcaster.END_OF_VIDEO_MAGIC_BYTES.decode()}')
 cmd_runner.run_cmd_with_realtime_output(cmd)
 
 while receive_file_proc.poll() is None:

--- a/utils/msend_file_to_receivers
+++ b/utils/msend_file_to_receivers
@@ -45,8 +45,8 @@ receive_file_proc = cmd_runner.run_dsh(cmd, include_broadcaster = False, wait_fo
 time.sleep(2)
 
 logger.info("Sending file to receivers...")
-cmd = (f'set -o pipefail && export SHELLOPTS && cat {shlex.quote(args.input_file)} | pv --rate-limit 4M | ' +
-    f'{root_dir}/bin/msend_video --end-of-video-magic-bytes {VideoBroadcaster.END_OF_VIDEO_MAGIC_BYTES.decode()}')
+cmd = (f'{root_dir}/bin/msend_video --end-of-video-magic-bytes {VideoBroadcaster.END_OF_VIDEO_MAGIC_BYTES.decode()} ' +
+    f'< {shlex.quote(args.input_file)}')
 cmd_runner.run_cmd_with_realtime_output(cmd)
 
 while receive_file_proc.poll() is None:


### PR DESCRIPTION
But only copy them if they are not already present on all receivers.

Also switch from buggy `pv` multicast send rate limiting method to `sleep` in the `msend_video` command to rate limit multicast sending. Avoids video corruption more robustly.