### PR TITLE
maybe fix git edge case

### DIFF
--- a/install/setup_broadcaster_and_receivers
+++ b/install/setup_broadcaster_and_receivers
@@ -125,7 +125,7 @@ def clone_and_pull_repo(cmd_runner, ssh_opts):
     clone_or_pull_repo_and_checkout_branch = (
         f'if [ ! -d "{ROOT_DIR}" ]; then echo "Cloning repo..." && ' +
         f'GIT_SSH_COMMAND="{ssh_opts}" git clone "{git_url}" "{ROOT_DIR}"; '
-        f'else echo "Pulling repo..." && GIT_SSH_COMMAND="{ssh_opts}" git -C "{ROOT_DIR}" pull; fi && ' +
+        f'else echo "Pulling repo..." && {{ GIT_SSH_COMMAND="{ssh_opts}" git -C "{ROOT_DIR}" pull || true }} ; fi && ' +
         f'git -C {ROOT_DIR} checkout {current_branch} && '
         # pull a second time after checking out the right branch. AFAIK, pull only updates the branch you are
         # currently on?

--- a/install/setup_broadcaster_and_receivers
+++ b/install/setup_broadcaster_and_receivers
@@ -128,7 +128,7 @@ def clone_and_pull_repo(cmd_runner, ssh_opts):
         f'else echo "Pulling repo..." && {{ GIT_SSH_COMMAND="{ssh_opts}" git -C "{ROOT_DIR}" pull || true }} ; fi && ' +
         f'git -C {ROOT_DIR} checkout {current_branch} && '
         # pull a second time after checking out the right branch. AFAIK, pull only updates the branch you are
-        # currently on?
+        # currently on? Also needed for scenarios like this: https://github.com/dasl-/piwall2/pull/28
         f'GIT_SSH_COMMAND="{ssh_opts}" git -C "{ROOT_DIR}" pull'
     )
     cmd_runner.run_dsh(clone_or_pull_repo_and_checkout_branch, include_broadcaster = True)


### PR DESCRIPTION
The intent is to fix a scenario like this:

1) create `my_feature_branch`, make commits to the branch, and check out the `my_feature_branch` branch on the broadcaster
2) we run `./install/setup_broadcaster_and_receivers`. Thus, receivers will also pull and checkout `my_feature_branch`
3) we merge `my_feature_branch` into main, delete `my_feature_branch`, and checkout `main` on the broadcaster
4) we run `./install/setup_broadcaster_and_receivers`, causing the receivers to `pull`, but since they are still on `my_feature_branch`, this fails with: 
```
pi@piwall1.local: Your configuration specifies to merge with the ref 'refs/heads/my_feature_branch'
pi@piwall1.local: from the remote, but no such ref was fetched.
```

